### PR TITLE
Fixed bug #50477

### DIFF
--- a/Documents/Documents.xcodeproj/project.pbxproj
+++ b/Documents/Documents.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D5DB0352658086C006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5DB0342658086B006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift */; };
+		1D5DB03A2658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5DB0392658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift */; };
+		1D5DB04F265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5DB04E265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift */; };
 		1D981FF32631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D981FF22631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift */; };
 		1D9820012631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9820002631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift */; };
 		1DE6D6BC2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE6D6BB2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift */; };
@@ -550,6 +553,9 @@
 /* Begin PBXFileReference section */
 		1B32667722AD980849E124F1 /* Pods_Documents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Documents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B402BC0B41F5EA0B160A88F /* Pods-Documents-DocumentsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Documents-DocumentsTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Documents-DocumentsTests/Pods-Documents-DocumentsTests.release.xcconfig"; sourceTree = "<group>"; };
+		1D5DB0342658086B006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeCacheCategoriesProvider.swift; sourceTree = "<group>"; };
+		1D5DB0392658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift; sourceTree = "<group>"; };
+		1D5DB04E265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift; sourceTree = "<group>"; };
 		1D981FF22631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeCategoriesProviderProtocol.swift; sourceTree = "<group>"; };
 		1D9820002631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeAppBasedCategoriesProvider.swift; sourceTree = "<group>"; };
 		1DE6D6BB2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeAPICategoriesProvider.swift; sourceTree = "<group>"; };
@@ -959,6 +965,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1D5DB04526584DBC006B4757 /* Business */ = {
+			isa = PBXGroup;
+			children = (
+				1D5DB04626584E30006B4757 /* Providers */,
+			);
+			path = Business;
+			sourceTree = "<group>";
+		};
+		1D5DB04626584E30006B4757 /* Providers */ = {
+			isa = PBXGroup;
+			children = (
+				1D5DB04726584E37006B4757 /* OnlyofficeCategories */,
+			);
+			path = Providers;
+			sourceTree = "<group>";
+		};
+		1D5DB04726584E37006B4757 /* OnlyofficeCategories */ = {
+			isa = PBXGroup;
+			children = (
+				1D5DB04E265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift */,
+			);
+			path = OnlyofficeCategories;
+			sourceTree = "<group>";
+		};
 		1D981FF02631A63C00144B57 /* OnlyofficeCategories */ = {
 			isa = PBXGroup;
 			children = (
@@ -966,6 +996,7 @@
 				1DE6D6C22631BDCF001B825B /* Factory */,
 				1D9820002631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift */,
 				1DE6D6BB2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift */,
+				1D5DB0392658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift */,
 			);
 			path = OnlyofficeCategories;
 			sourceTree = "<group>";
@@ -974,6 +1005,7 @@
 			isa = PBXGroup;
 			children = (
 				1D981FF22631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift */,
+				1D5DB0342658086B006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1597,6 +1629,7 @@
 		FCCDE6762049734000CFC653 /* DocumentsTests */ = {
 			isa = PBXGroup;
 			children = (
+				1D5DB04526584DBC006B4757 /* Business */,
 				FCCDE68120497C0D00CFC653 /* documents */,
 				FCCDE67F204973F500CFC653 /* ASCDocumentConverterTest.swift */,
 				FCCDE6792049734000CFC653 /* Info.plist */,
@@ -2784,6 +2817,7 @@
 				FC4D864820C50AE00047B871 /* MBProgressHUD+Extension.swift in Sources */,
 				FC4D864220C50AE00047B871 /* Common+Extension.swift in Sources */,
 				FC4D864C20C50AE00047B871 /* UIColor+Extension.swift in Sources */,
+				1D5DB04F265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift in Sources */,
 				FC4D864A20C50AE00047B871 /* UIAlertController+Extension.swift in Sources */,
 				FC4D864D20C50AE00047B871 /* UIControl+Extension.swift in Sources */,
 				FC4D864B20C50AE00047B871 /* UIAlertController+SwiftAlertController.swift in Sources */,
@@ -2816,6 +2850,7 @@
 				FCA7500822BB9CD500991682 /* UITableViewCell+Extensions.swift in Sources */,
 				FC1EA5D21ECF2A6D008FEE2E /* ASCSettingsViewController.swift in Sources */,
 				FC1EA5CB1ECECBC3008FEE2E /* ASCBaseNavigationController.swift in Sources */,
+				1D5DB03A2658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift in Sources */,
 				FCD33B5B21C93C2B00D52DAF /* ASCCloudsEmptyViewController.swift in Sources */,
 				FCB8A39221C27EE000CF74FA /* ASCDeviceCategoryViewController.swift in Sources */,
 				FC28F2C61E8D1BB200A8F985 /* ASCEntityManager.swift in Sources */,
@@ -2853,6 +2888,7 @@
 				FC5E2D8D1E8A4C8B0079626B /* ASCImageViewController.swift in Sources */,
 				FC41D8062265D99C00A155C2 /* ASCFileStatus.swift in Sources */,
 				FCEF9D331ED2D18500627BA5 /* ASCPasscodeLockConfiguration.swift in Sources */,
+				1D5DB0352658086C006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift in Sources */,
 				1D981FF32631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift in Sources */,
 				FCEF9D241ED2C94300627BA5 /* PasscodeLockConfigurationType.swift in Sources */,
 				FC9161DC1EE965970031B6DB /* ASCGroup.swift in Sources */,

--- a/Documents/Documents/Code/Business/ASCConstants.swift
+++ b/Documents/Documents/Code/Business/ASCConstants.swift
@@ -237,6 +237,9 @@ class ASCConstants {
         return [:]
     }
 
+    struct CacheKeys {
+        static let onlyofficeCategoriesPrefix = "onlyoffice_categories"
+    }
 }
 
 

--- a/Documents/Documents/Code/Business/Providers/OnlyofficeCategories/ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift
+++ b/Documents/Documents/Code/Business/Providers/OnlyofficeCategories/ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift
@@ -1,0 +1,61 @@
+//
+//  ASCOnlyOfficeUserDefaultsCacheCategoriesProvider.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 21.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+class ASCOnlyofficeUserDefaultsCacheCategoriesProvider {
+    
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    
+    public func getKey(for account: ASCAccount) -> String? {
+        guard let email = account.email,
+              let portal = account.portal,
+              !email.isEmpty,
+              !portal.isEmpty
+        else {
+            return nil
+        }
+        return "\(ASCConstants.CacheKeys.onlyofficeCategoriesPrefix)_\(email)_\(portal)"
+    }
+}
+
+extension ASCOnlyofficeUserDefaultsCacheCategoriesProvider: ASCOnlyofficeCacheCategoriesProvider {
+    
+    func save(for account: ASCAccount, categories: [ASCOnlyofficeCategory]) -> Error? {
+        guard let key = getKey(for: account) else {
+            return nil
+        }
+        
+        do {
+            let data = try self.encoder.encode(categories)
+        
+            UserDefaults.standard.setValue(data, forKey: key)
+        } catch let error {
+            return error
+        }
+        return nil
+    }
+    
+    func getCategories(for account: ASCAccount) -> [ASCOnlyofficeCategory] {
+        guard let key = getKey(for: account), let data = UserDefaults.standard.data(forKey: key) else {
+            return []
+        }
+        do {
+            return try self.decoder.decode([ASCOnlyofficeCategory].self, from: data)
+        } catch {
+            return []
+        }
+    }
+    
+    func clearCache() {
+        UserDefaults.standard.dictionaryRepresentation().keys
+            .filter({ $0.hasPrefix(ASCConstants.CacheKeys.onlyofficeCategoriesPrefix) })
+            .forEach({ UserDefaults.standard.removeObject(forKey: $0) })
+    }
+}

--- a/Documents/Documents/Code/Business/Providers/OnlyofficeCategories/Protocols/ASCOnlyofficeCacheCategoriesProvider.swift
+++ b/Documents/Documents/Code/Business/Providers/OnlyofficeCategories/Protocols/ASCOnlyofficeCacheCategoriesProvider.swift
@@ -1,0 +1,15 @@
+//
+//  ASCOnlyOfficeCacheCategoriesProvider.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 21.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+protocol ASCOnlyofficeCacheCategoriesProvider {
+    func save(for account: ASCAccount, categories: [ASCOnlyofficeCategory]) -> Error?
+    func getCategories(for account: ASCAccount) -> [ASCOnlyofficeCategory]
+    func clearCache()
+}

--- a/Documents/Documents/Code/Controllers/Documents/View/ASCDocumentsEmptyView.swift
+++ b/Documents/Documents/Code/Controllers/Documents/View/ASCDocumentsEmptyView.swift
@@ -59,7 +59,7 @@ class ASCDocumentsEmptyView: UIView {
 
             isUserInteractionEnabled = true
             
-            actionButton.styleType = .action
+            actionButton?.styleType = .action
 //
 //            actionButton?.backgroundColor = ASCConstants.Colors.brendAction
 //            actionButton?.layer.cornerRadius = 5

--- a/Documents/Documents/Code/Controllers/Settings/ASCSettingsViewController.swift
+++ b/Documents/Documents/Code/Controllers/Settings/ASCSettingsViewController.swift
@@ -180,6 +180,9 @@ class ASCSettingsViewController: UITableViewController, MFMailComposeViewControl
                     SDImageCache.shared.clearMemory()
                     SDImageCache.shared.clearDisk()
                     
+                    // Clear categories
+                    ASCOnlyofficeUserDefaultsCacheCategoriesProvider().clearCache()
+                    
                     hud.setSuccessState()
                     hud.hide(animated: true, afterDelay: 2)
                     

--- a/Documents/DocumentsTests/Business/Providers/OnlyofficeCategories/ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift
+++ b/Documents/DocumentsTests/Business/Providers/OnlyofficeCategories/ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift
@@ -1,0 +1,117 @@
+//
+//  ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 21.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import XCTest
+import UIKit
+@testable import Documents
+
+class ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests: XCTestCase {
+
+    var sut: ASCOnlyofficeUserDefaultsCacheCategoriesProvider!
+    var categoryFoo: ASCOnlyofficeCategory!
+    var account: ASCAccount!
+    
+    let email = "foo@bar.com"
+    let portal =  "https://portal.com"
+    
+    override func setUp() {
+        sut = ASCOnlyofficeUserDefaultsCacheCategoriesProviderMock()
+        
+        categoryFoo = ASCOnlyofficeCategory()
+        categoryFoo.title = "Foo"
+        categoryFoo.subtitle = "foo"
+        let folder = ASCFolder()
+        folder.id = "@my"
+        folder.rootFolderType = .onlyofficeUser
+        folder.title = "Foo"
+        categoryFoo.folder = folder
+        
+        account = ASCAccount(JSON: ["email": email, "portal": portal])
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        UserDefaults.standard.set("", forKey: sut.getKey(for: account)!)
+        sut = nil
+        categoryFoo = nil
+        account = nil
+
+        super.tearDown()
+    }
+    
+    func testKeyIsNotEmpty() {
+        guard let key = sut.getKey(for: account) else {
+            XCTFail("key is nil")
+            return
+        }
+        XCTAssertEqual(key, "\(ASCConstants.CacheKeys.onlyofficeCategoriesPrefix)_\(email)_\(portal)_tests")
+    }
+    
+    func testAccountEmailAndPortalIsNotEmpty() {
+        XCTAssertEqual(account?.email, email)
+        XCTAssertEqual(account?.portal, portal)
+    }
+
+    func testWhenSaveCategoryGetTheSameCategory() {
+        let error = sut.save(for: account, categories: [categoryFoo])
+        
+        XCTAssertNil(error)
+        
+        XCTAssertEqual(sut.getCategories(for: account!), [categoryFoo])
+    }
+    
+    func testWhenSaveCategoryAndEqualingWithAnotherThanFail() {
+        
+        let error = sut.save(for: account, categories: [categoryFoo])
+        
+        XCTAssertNil(error)
+        
+        let categoryBar = ASCOnlyofficeCategory()
+        categoryBar.title = "Bar"
+        categoryBar.subtitle = "bar"
+
+        XCTAssertNotEqual(sut.getCategories(for: account), [categoryBar])
+    }
+    
+    func testWhenAddTwoCategoriesAngGetTheSameCategories() {
+        let categoryBar = ASCOnlyofficeCategory()
+        categoryBar.title = "Bar"
+        categoryBar.subtitle = "bar"
+        
+        let error = sut.save(for: account, categories: [categoryFoo, categoryBar])
+        
+        XCTAssertNil(error)
+        
+        let cachedCategories = sut.getCategories(for: account);
+
+        XCTAssertEqual(cachedCategories, [categoryFoo, categoryBar])
+    }
+    
+    func testWhenSaveCategoriesAndCleacCasheThenCachedEmpty() {
+        let error = sut.save(for: account, categories: [categoryFoo])
+        
+        XCTAssertNil(error)
+        
+        XCTAssertEqual(sut.getCategories(for: account!), [categoryFoo])
+        
+        sut.clearCache()
+        
+        XCTAssertEqual(sut.getCategories(for: account!), [])
+    }
+}
+
+extension ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests {
+    class ASCOnlyofficeUserDefaultsCacheCategoriesProviderMock: ASCOnlyofficeUserDefaultsCacheCategoriesProvider {
+        override func getKey(for account: ASCAccount) -> String? {
+            guard let key = super.getKey(for: account) else {
+                return nil
+            }
+            return "\(key)_tests"
+        }
+    }
+}


### PR DESCRIPTION
Now the category list is oriented to loaded categories if they are not empty, otherwise to cached categories. The activity indicator works while both category sources are empty.