### PR TITLE
Fixed bug #47332

### DIFF
--- a/Documents/Documents.xcodeproj/project.pbxproj
+++ b/Documents/Documents.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		1D12D35E265E467900C8C519 /* ASCOnlyofficeCategoriesProviderFilterProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D12D35D265E467900C8C519 /* ASCOnlyofficeCategoriesProviderFilterProxy.swift */; };
+		1D1A2E1F2660F93600D0335B /* ASCLoadedViewControllerByProviderAndFolderFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A2E1E2660F93600D0335B /* ASCLoadedViewControllerByProviderAndFolderFinderTests.swift */; };
+		1D1A2E282660F99800D0335B /* ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A2E272660F99800D0335B /* ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift */; };
+		1D1A2E322660FE6E00D0335B /* ASCLoadedViewControllerFinderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A2E312660FE6E00D0335B /* ASCLoadedViewControllerFinderProtocol.swift */; };
+		1D1A2E3A2660FF7F00D0335B /* ASCLoadedVCFinderModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A2E392660FF7F00D0335B /* ASCLoadedVCFinderModels.swift */; };
+		1D1A2E412661018100D0335B /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE186492628CFE70086D21B /* Assets.swift */; };
+		1D1A2E46266103AE00D0335B /* ASCLoadedViewControllerFinderProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A2E45266103AE00D0335B /* ASCLoadedViewControllerFinderProtocolTests.swift */; };
 		1D5DB0352658086C006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5DB0342658086B006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift */; };
 		1D5DB03A2658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5DB0392658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift */; };
 		1D5DB04F265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5DB04E265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift */; };
@@ -558,6 +564,11 @@
 		1B32667722AD980849E124F1 /* Pods_Documents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Documents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B402BC0B41F5EA0B160A88F /* Pods-Documents-DocumentsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Documents-DocumentsTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Documents-DocumentsTests/Pods-Documents-DocumentsTests.release.xcconfig"; sourceTree = "<group>"; };
 		1D12D35D265E467900C8C519 /* ASCOnlyofficeCategoriesProviderFilterProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeCategoriesProviderFilterProxy.swift; sourceTree = "<group>"; };
+		1D1A2E1E2660F93600D0335B /* ASCLoadedViewControllerByProviderAndFolderFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCLoadedViewControllerByProviderAndFolderFinderTests.swift; sourceTree = "<group>"; };
+		1D1A2E272660F99800D0335B /* ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift; sourceTree = "<group>"; };
+		1D1A2E312660FE6E00D0335B /* ASCLoadedViewControllerFinderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCLoadedViewControllerFinderProtocol.swift; sourceTree = "<group>"; };
+		1D1A2E392660FF7F00D0335B /* ASCLoadedVCFinderModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCLoadedVCFinderModels.swift; sourceTree = "<group>"; };
+		1D1A2E45266103AE00D0335B /* ASCLoadedViewControllerFinderProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCLoadedViewControllerFinderProtocolTests.swift; sourceTree = "<group>"; };
 		1D5DB0342658086B006B4757 /* ASCOnlyofficeCacheCategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeCacheCategoriesProvider.swift; sourceTree = "<group>"; };
 		1D5DB0392658097E006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeUserDefaultsCacheCategoriesProvider.swift; sourceTree = "<group>"; };
 		1D5DB04E265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift; sourceTree = "<group>"; };
@@ -978,9 +989,45 @@
 			path = Proxy;
 			sourceTree = "<group>";
 		};
+		1D1A2E1D2660F72900D0335B /* LoadedViewControllersFinders */ = {
+			isa = PBXGroup;
+			children = (
+				1D1A2E1E2660F93600D0335B /* ASCLoadedViewControllerByProviderAndFolderFinderTests.swift */,
+				1D1A2E45266103AE00D0335B /* ASCLoadedViewControllerFinderProtocolTests.swift */,
+			);
+			path = LoadedViewControllersFinders;
+			sourceTree = "<group>";
+		};
+		1D1A2E262660F97900D0335B /* LoadedViewControllersFinders */ = {
+			isa = PBXGroup;
+			children = (
+				1D1A2E2F2660FE3700D0335B /* Protocols */,
+				1D1A2E302660FE5000D0335B /* Models */,
+				1D1A2E272660F99800D0335B /* ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift */,
+			);
+			path = LoadedViewControllersFinders;
+			sourceTree = "<group>";
+		};
+		1D1A2E2F2660FE3700D0335B /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				1D1A2E312660FE6E00D0335B /* ASCLoadedViewControllerFinderProtocol.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		1D1A2E302660FE5000D0335B /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				1D1A2E392660FF7F00D0335B /* ASCLoadedVCFinderModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		1D5DB04526584DBC006B4757 /* Business */ = {
 			isa = PBXGroup;
 			children = (
+				1D1A2E1D2660F72900D0335B /* LoadedViewControllersFinders */,
 				1D5DB04626584E30006B4757 /* Providers */,
 			);
 			path = Business;
@@ -1574,6 +1621,7 @@
 			children = (
 				FC41D8002265D6C900A155C2 /* Enums */,
 				FC0F01DD216F43FF008D79A5 /* Providers */,
+				1D1A2E262660F97900D0335B /* LoadedViewControllersFinders */,
 				FCDB31A71E7C116E00907FC0 /* ASCConstants.swift */,
 				FC56B5C520C017C300557C1F /* ASCStyles.swift */,
 				FCC3E9BD214006B1001B216C /* ASCLocalization.swift */,
@@ -2832,9 +2880,11 @@
 				FC4D864320C50AE00047B871 /* Dictionary+Extension.swift in Sources */,
 				FC4D864020C50A710047B871 /* UIDevice+Extension.swift in Sources */,
 				FC4D864820C50AE00047B871 /* MBProgressHUD+Extension.swift in Sources */,
+				1D1A2E412661018100D0335B /* Assets.swift in Sources */,
 				FC4D864220C50AE00047B871 /* Common+Extension.swift in Sources */,
 				FC4D864C20C50AE00047B871 /* UIColor+Extension.swift in Sources */,
 				1D5DB04F265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift in Sources */,
+				1D1A2E46266103AE00D0335B /* ASCLoadedViewControllerFinderProtocolTests.swift in Sources */,
 				FC4D864A20C50AE00047B871 /* UIAlertController+Extension.swift in Sources */,
 				FC4D864D20C50AE00047B871 /* UIControl+Extension.swift in Sources */,
 				FC4D864B20C50AE00047B871 /* UIAlertController+SwiftAlertController.swift in Sources */,
@@ -2845,6 +2895,7 @@
 				FC4D864620C50AE00047B871 /* UIView+Extension.swift in Sources */,
 				FC77846E24756D17005ED631 /* UIDevice+DeviceKit.swift in Sources */,
 				FC4D864520C50AE00047B871 /* Date+Extension.swift in Sources */,
+				1D1A2E1F2660F93600D0335B /* ASCLoadedViewControllerByProviderAndFolderFinderTests.swift in Sources */,
 				FC77846C24756CC2005ED631 /* ASCFolderProviderType.swift in Sources */,
 				FCD31F4524BDF2E200774ACD /* ASCLogger.swift in Sources */,
 				FC4D864920C50AE00047B871 /* Path+Extension.swift in Sources */,
@@ -2860,6 +2911,7 @@
 				FC7CF5101EF3E76F00C0A64F /* ASCStringTransform.swift in Sources */,
 				FCEF9D251ED2C94300627BA5 /* PasscodeLockStateType.swift in Sources */,
 				FCC552B61EC3196B00F645EE /* ASCCountryCodeViewController.swift in Sources */,
+				1D1A2E282660F99800D0335B /* ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift in Sources */,
 				FC28F2C41E8D131800A8F985 /* ASCCreateEntity.swift in Sources */,
 				FC301A25230D6F1F00DC25CA /* ASCFileCell.swift in Sources */,
 				FC12ACF42567D1C300FF1CBB /* ASCAnalytics.swift in Sources */,
@@ -3035,6 +3087,7 @@
 				FCEF9D1D1ED2C94300627BA5 /* ChangePasscodeState.swift in Sources */,
 				FC9161DA1EE949420031B6DB /* ASCShareInfo.swift in Sources */,
 				FC707C3D25AC5691004CB85B /* UILabel+Extension.swift in Sources */,
+				1D1A2E322660FE6E00D0335B /* ASCLoadedViewControllerFinderProtocol.swift in Sources */,
 				FC7F786B236ACBB00026E260 /* ASCConnectStorageGoogleController.swift in Sources */,
 				FC6106FD1F9E30B9002A25C8 /* ASCAvatarCollectionViewCell.swift in Sources */,
 				FC6839A221B81B1D00251CEA /* ASCOwnCloudProvider.swift in Sources */,
@@ -3044,6 +3097,7 @@
 				FC82827F21C3CC01005AF726 /* ASCDeviceSplitViewController.swift in Sources */,
 				FCA7501122BBD65A00991682 /* ASCCreateEntityView.swift in Sources */,
 				FC6D9A512355CDC100A970C6 /* ASCDropboxProvider.swift in Sources */,
+				1D1A2E3A2660FF7F00D0335B /* ASCLoadedVCFinderModels.swift in Sources */,
 				1D12D35E265E467900C8C519 /* ASCOnlyofficeCategoriesProviderFilterProxy.swift in Sources */,
 				FCB1BEC31E8E5E55004C7967 /* MBProgressHUD+Extension.swift in Sources */,
 				FC066AB4252DB7C5007357F7 /* ObservableProxy.swift in Sources */,

--- a/Documents/Documents/Code/Business/LoadedViewControllersFinders/ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift
+++ b/Documents/Documents/Code/Business/LoadedViewControllersFinders/ASCLoadedDocumentViewControllerByProviderAndFolderFinder.swift
@@ -1,0 +1,83 @@
+//
+//  LoadedViewControllerByProviderAndFolderFinder.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 28.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class ASCLoadedDocumentViewControllerByProviderAndFolderFinder: ASCLoadedViewControllerFinderProtocol {
+    
+    func find(requestModel: ASCLoadedVCFinderModels.DocumentsVC.Request) -> ASCLoadedVCFinderModels.DocumentsVC.Response {
+        
+        let nilResult = ASCLoadedVCFinderModels.DocumentsVC.Response(viewController: nil)
+        
+        guard !requestModel.folderId.isEmpty, !requestModel.providerId.isEmpty else {
+            return nilResult
+        }
+        
+        let allDocumentsNavigationControllers = getAllASCDocumentsNavigationControllers()
+        
+        guard let navigationControllerWithNeededProvider = getFirstASCDocumentsNavigationController(
+                navigationControllers: allDocumentsNavigationControllers,
+                withProviderId: requestModel.providerId)
+        else {
+            return nilResult
+        }
+        
+        guard let documentsViewControllerWithNeededFolder = getFirstASCDocumentsViewController(
+                navigationController: navigationControllerWithNeededProvider,
+                withFolderId: requestModel.folderId)
+        else {
+            return nilResult
+        }
+        
+        return ASCLoadedVCFinderModels.DocumentsVC.Response(viewController: documentsViewControllerWithNeededFolder)
+    }
+    
+    func getAllASCDocumentsNavigationControllers() -> [ASCDocumentsNavigationController] {
+        guard let root = self.getRootViewController() else {
+            return []
+        }
+        
+        var queue: [UIViewController] = [];
+        var values: [ASCDocumentsNavigationController] = [];
+        
+        queue.append(root);
+        
+        while(!queue.isEmpty){
+            let vc = queue.removeFirst()
+            if let nc = vc as? ASCDocumentsNavigationController {
+                values.append(nc)
+            } else {
+                queue.append(contentsOf: vc.children)
+            }
+        }
+        return values;
+    }
+
+    func getFirstASCDocumentsNavigationController(navigationControllers: [ASCDocumentsNavigationController], withProviderId providerId: String) -> ASCDocumentsNavigationController? {
+        guard !navigationControllers.isEmpty, !providerId.isEmpty else {
+            return nil
+        }
+
+        return navigationControllers.first(where: {
+            guard let documentsVC = $0.children.first as? ASCDocumentsViewController else {
+                return false
+            }
+            return documentsVC.provider?.id == providerId
+        })
+    }
+    
+    func getFirstASCDocumentsViewController(navigationController: ASCDocumentsNavigationController, withFolderId folderId: String) -> ASCDocumentsViewController? {
+        for child in navigationController.children {
+            if let documentsVC = child as? ASCDocumentsViewController, documentsVC.folder?.id == folderId {
+                return documentsVC
+            }
+        }
+        return nil
+    }
+}

--- a/Documents/Documents/Code/Business/LoadedViewControllersFinders/Models/ASCLoadedVCFinderModels.swift
+++ b/Documents/Documents/Code/Business/LoadedViewControllersFinders/Models/ASCLoadedVCFinderModels.swift
@@ -1,0 +1,22 @@
+//
+//  ASCLoadedViewControllerFinderModels.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 28.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+enum ASCLoadedVCFinderModels {
+    enum DocumentsVC {
+        struct Request {
+            var folderId: String
+            var providerId: String
+        }
+        
+        struct Response {
+            var viewController: ASCDocumentsViewController?
+        }
+    }
+}

--- a/Documents/Documents/Code/Business/LoadedViewControllersFinders/Protocols/ASCLoadedViewControllerFinderProtocol.swift
+++ b/Documents/Documents/Code/Business/LoadedViewControllersFinders/Protocols/ASCLoadedViewControllerFinderProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  ASCLoadedViewControllerFinderProtocol.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 28.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+protocol ASCLoadedViewControllerFinderProtocol {
+    func find(requestModel: ASCLoadedVCFinderModels.DocumentsVC.Request) -> ASCLoadedVCFinderModels.DocumentsVC.Response
+}
+
+extension ASCLoadedViewControllerFinderProtocol {
+    func getRootViewController() -> UIViewController? {
+        UIApplication.shared.windows.first?.rootViewController
+    }
+}

--- a/Documents/DocumentsTests/Business/LoadedViewControllersFinders/ASCLoadedViewControllerByProviderAndFolderFinderTests.swift
+++ b/Documents/DocumentsTests/Business/LoadedViewControllersFinders/ASCLoadedViewControllerByProviderAndFolderFinderTests.swift
@@ -1,0 +1,210 @@
+//
+//  ASCLoadedViewControllerByProviderAndFolderFinderTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 28.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import XCTest
+import UIKit
+@testable import Documents
+
+class ASCLoadedViewControllerByProviderAndFolderFinderTests: XCTestCase {
+    
+    var sut: ASCLoadedDocumentViewControllerByProviderAndFolderFinder!
+    var tabbar: UITabBarController!
+
+    override func setUpWithError() throws {
+        sut = ASCLoadedDocumentViewControllerByProviderAndFolderFinder()
+        
+        tabbar = UITabBarController()
+        tabbar.addChild(ASCDeviceSplitViewController())
+        tabbar.addChild(ASCOnlyofficeSplitViewController())
+        tabbar.addChild(ASCCloudsSplitViewController())
+        tabbar.addChild(UIViewController())
+        
+        UIApplication.shared.windows.first?.rootViewController = tabbar
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        tabbar = nil
+    }
+    
+    func testDoNotSetDocumentVCAndWhenTryToFindThenNil() {
+        let request = ASCLoadedVCFinderModels.DocumentsVC.Request(folderId: "Foo", providerId: "Bar")
+        
+        XCTAssertNil(sut.find(requestModel: request).viewController)
+    }
+    
+    func testWhenEmptyIdThenNil() {
+        let request = ASCLoadedVCFinderModels.DocumentsVC.Request(folderId: "", providerId: "")
+        
+        XCTAssertNil(sut.find(requestModel: request).viewController)
+    }
+    
+    func testSetAndSetThreeDocumentsNVCThenFindThree() {
+        let fistDocumentsNVC = ASCDocumentsNavigationController()
+        let secondDocumentsNVC = ASCDocumentsNavigationController()
+        let thirdDocumentsNVC = ASCDocumentsNavigationController()
+        
+        (tabbar.children[0] as! UISplitViewController).viewControllers = [UIViewController(), secondDocumentsNVC]
+        let nc = UINavigationController()
+        nc.viewControllers = [UIViewController(), UIViewController()]
+        (tabbar.children[1] as! UISplitViewController).viewControllers = [thirdDocumentsNVC, nc]
+        (tabbar.children[2] as! UISplitViewController).viewControllers = [UIViewController(), UIViewController()]
+        tabbar.addChild(fistDocumentsNVC)
+        
+        let documentsViewControllers = sut.getAllASCDocumentsNavigationControllers()
+        
+        XCTAssertEqual(documentsViewControllers.count, 3)
+        XCTAssertTrue(documentsViewControllers[0] === fistDocumentsNVC)
+        XCTAssertTrue(documentsViewControllers[1] === secondDocumentsNVC)
+        XCTAssertTrue(documentsViewControllers[2] === thirdDocumentsNVC)
+    }
+    
+    func testWhenSetZeroDocumentsNCReturnsNul() {
+        XCTAssertNil(sut.getFirstASCDocumentsNavigationController(navigationControllers: [], withProviderId: ""))
+    }
+    
+    func testWhenSetThreeDocumentsNCFindOne() {
+        let fistDocumentsNVC = ASCDocumentsNavigationController()
+        fistDocumentsNVC.addChild(MockASCDocumentsViewController.get(folderId: "Foo", providerId: "FooFoo"))
+        let secondDocumentsNVC = ASCDocumentsNavigationController()
+        secondDocumentsNVC.addChild(MockASCDocumentsViewController.get(folderId: "Bar", providerId: "BarBar"))
+        let thirdDocumentsNVC = ASCDocumentsNavigationController()
+        thirdDocumentsNVC.addChild(MockASCDocumentsViewController.get(folderId: "Baz", providerId: "BazBaz"))
+        
+        let foundFirstNVC = sut.getFirstASCDocumentsNavigationController(navigationControllers: [fistDocumentsNVC, secondDocumentsNVC, thirdDocumentsNVC], withProviderId: "FooFoo")
+        
+        XCTAssertNotNil(foundFirstNVC)
+        XCTAssertTrue(foundFirstNVC === fistDocumentsNVC)
+        
+        let foundSecondtNVC = sut.getFirstASCDocumentsNavigationController(navigationControllers: [fistDocumentsNVC, secondDocumentsNVC, thirdDocumentsNVC], withProviderId: "BarBar")
+
+        XCTAssertNotNil(foundSecondtNVC)
+        XCTAssertTrue(foundSecondtNVC === secondDocumentsNVC)
+
+        let foundThirdNVC = sut.getFirstASCDocumentsNavigationController(navigationControllers: [fistDocumentsNVC, secondDocumentsNVC, thirdDocumentsNVC], withProviderId: "BazBaz")
+
+        XCTAssertNotNil(foundThirdNVC)
+        XCTAssertTrue(foundThirdNVC === thirdDocumentsNVC)
+        
+    }
+    
+    func testSetOnSecondLevelDocumentsOfNavigiationControllerVCAndFindIt() {
+        let navigationController = ASCDocumentsNavigationController()
+        let documentsVC = MockASCDocumentsViewController.get(folderId: "Foo", providerId: "FooFoo")
+        
+        navigationController.addChild(MockASCDocumentsViewController.get(folderId: "Bar", providerId: "BarBar"))
+        navigationController.addChild(documentsVC)
+        navigationController.addChild(MockASCDocumentsViewController.get(folderId: "Baz", providerId: "BazBaz"))
+        
+        let foundVC = sut.getFirstASCDocumentsViewController(navigationController: navigationController, withFolderId: "Foo")
+        
+        XCTAssertNotNil(foundVC)
+        XCTAssertTrue(documentsVC === foundVC)
+    }
+    
+    
+    func testSetDocumentVCToFirstTabFindSuccess() {
+        
+        let deviceNC = ASCDocumentsNavigationController()
+        deviceNC.addChild(MockASCDocumentsViewController.get(folderId: "Foo1", providerId: "Foo"))
+        deviceNC.addChild(MockASCDocumentsViewController.get(folderId: "Foo1/Foo1.1", providerId: "Foo"))
+        deviceNC.addChild(MockASCDocumentsViewController.get(folderId: "Foo1/Foo1.1/Foo1.1.1", providerId: "Foo"))
+        
+        let onlyofficeNC = ASCDocumentsNavigationController()
+        onlyofficeNC.addChild(MockASCDocumentsViewController.get(folderId: "Bar1", providerId: "Bar"))
+        onlyofficeNC.addChild(MockASCDocumentsViewController.get(folderId: "Bar1/Bar1.1", providerId: "Bar"))
+        onlyofficeNC.addChild(MockASCDocumentsViewController.get(folderId: "Bar1/Bar1.1/Bar1.1.1", providerId: "Bar"))
+        
+        let cloudNC = ASCDocumentsNavigationController()
+        cloudNC.addChild(MockASCDocumentsViewController.get(folderId: "Baz1", providerId: "Baz"))
+        cloudNC.addChild(MockASCDocumentsViewController.get(folderId: "Baz1/Baz1.1", providerId: "Baz"))
+        cloudNC.addChild(MockASCDocumentsViewController.get(folderId: "Baz1/Baz1.1/Baz1.1.1", providerId: "Baz"))
+        cloudNC.addChild(MockASCDocumentsViewController.get(folderId: "Baz1/Baz1.1/Baz1.1.1/Baz1.1.1.1", providerId: "Baz"))
+        
+        (tabbar.children[0] as! ASCDeviceSplitViewController).viewControllers = [UIViewController(), deviceNC]
+        (tabbar.children[1] as! ASCOnlyofficeSplitViewController).viewControllers = [UIViewController(), onlyofficeNC]
+        (tabbar.children[2] as! ASCCloudsSplitViewController).viewControllers = [UIViewController(), cloudNC]
+        
+        var response = sut.find(requestModel: .init(folderId: "Foo1/Foo1.1/Foo1.1.1", providerId: "Bar"))
+        
+        XCTAssertNil(response.viewController)
+        
+        response = sut.find(requestModel: .init(folderId: "Foo1/Foo1.1/Foo1.1.1", providerId: "Foo"))
+        XCTAssertNotNil(response.viewController)
+        XCTAssertEqual(response.viewController?.folder?.id, "Foo1/Foo1.1/Foo1.1.1")
+        XCTAssertEqual(response.viewController?.provider?.id, "Foo")
+        
+        response = sut.find(requestModel: .init(folderId: "Bar1/Bar1.1", providerId: "Bar"))
+        XCTAssertNotNil(response.viewController)
+        XCTAssertEqual(response.viewController?.folder?.id, "Bar1/Bar1.1")
+        XCTAssertEqual(response.viewController?.provider?.id, "Bar")
+        
+        response = sut.find(requestModel: .init(folderId: "Baz1/Baz1.1/Baz1.1.1/Baz1.1.1.1", providerId: "Baz"))
+        XCTAssertNotNil(response.viewController)
+        XCTAssertEqual(response.viewController?.folder?.id, "Baz1/Baz1.1/Baz1.1.1/Baz1.1.1.1")
+        XCTAssertEqual(response.viewController?.provider?.id, "Baz")
+        
+        XCTAssertEqual(sut.getAllASCDocumentsNavigationControllers().count, 3)
+        
+    }
+}
+
+extension ASCLoadedViewControllerByProviderAndFolderFinderTests {
+    class MockASCDocumentsViewController: ASCDocumentsViewController {
+        var innerFolder: ASCFolder?
+        var innerProvider: ASCFileProviderProtocol?
+        
+        override var folder: ASCFolder? {
+            get { innerFolder }
+            set { innerFolder = newValue }
+        }
+        override var provider: ASCFileProviderProtocol? {
+            get { innerProvider }
+            set { innerProvider = newValue }
+        }
+        
+        static func get(folderId: String, providerId: String) -> MockASCDocumentsViewController {
+            let documentsVC = MockASCDocumentsViewController()
+            documentsVC.provider = MockFileProvider(id: providerId)
+            documentsVC.folder = MockFolder(id: folderId)
+            
+            return documentsVC
+        }
+        
+        init() {
+            super.init(nibName: "", bundle: nil)
+            UserDefaults.standard.addObserver(self, forKeyPath: ASCConstants.SettingsKeys.sortDocuments, options: [.new], context: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(updateFileInfo(_:)), name: ASCConstants.Notifications.updateFileInfo, object: nil)
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+    
+    class MockFileProvider: ASCOnlyofficeProvider {
+        let innerId: String
+        override var id: String? {
+            get {
+                innerId
+            }
+        }
+        
+        init(id: String) {
+            self.innerId = id
+            super.init()
+        }
+    }
+    
+    class MockFolder: ASCFolder {
+        convenience init(id: String) {
+            self.init()
+            self.id = id
+        }
+    }
+}

--- a/Documents/DocumentsTests/Business/LoadedViewControllersFinders/ASCLoadedViewControllerFinderProtocolTests.swift
+++ b/Documents/DocumentsTests/Business/LoadedViewControllersFinders/ASCLoadedViewControllerFinderProtocolTests.swift
@@ -1,0 +1,41 @@
+//
+//  ASCLoadedViewControllerFinderProtocolTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 28.05.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import XCTest
+import UIKit
+@testable import Documents
+
+class ASCLoadedViewControllerFinderProtocolTests: XCTestCase {
+    
+    var sut: ASCLoadedViewControllerFinderProtocol!
+
+    override func setUpWithError() throws {
+        sut = MockASCLoadedViewControllerFinderProtocol()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func testSetRootVCWhenGetRootVCWeGetTheSameRootVC() {
+        let vc = ASCRootController()
+        
+        UIApplication.shared.windows.first?.rootViewController = vc
+    
+        let gettedRootVC = sut.getRootViewController()
+        
+        XCTAssertNotNil(gettedRootVC)
+        XCTAssertTrue(gettedRootVC === vc)
+    }
+
+    class MockASCLoadedViewControllerFinderProtocol: ASCLoadedViewControllerFinderProtocol {
+        func find(requestModel: ASCLoadedVCFinderModels.DocumentsVC.Request) -> ASCLoadedVCFinderModels.DocumentsVC.Response {
+            ASCLoadedVCFinderModels.DocumentsVC.Response(viewController: nil)
+        }
+    }
+}


### PR DESCRIPTION
When we move/copy an entity from provider to provider, we insert the entity into the target table
When we move/copy an entity inside a provider, we update the target screen