### PR TITLE
Fixed bug 52437

### DIFF
--- a/Documents/Documents.xcodeproj/project.pbxproj
+++ b/Documents/Documents.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		1D8DF02F2639B6B10054B2F9 /* ASCOneDriveProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8DF02E2639B6B10054B2F9 /* ASCOneDriveProvider.swift */; };
 		1D981FF32631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D981FF22631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift */; };
 		1D9820012631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9820002631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift */; };
+		1D9B7FEA26FA5A0000D06E9B /* ASCSharingOprionsInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B7FE926FA5A0000D06E9B /* ASCSharingOprionsInteractorTests.swift */; };
 		1D9B807E2673EBEC0020B5ED /* ASCSwitchRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B807D2673EBEC0020B5ED /* ASCSwitchRowViewModel.swift */; };
 		1D9B80842673F5D70020B5ED /* ASCReusedIdentifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B80832673F5D70020B5ED /* ASCReusedIdentifierProtocol.swift */; };
 		1D9B808F2674001D0020B5ED /* ASCAccessRowTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B808E2674001C0020B5ED /* ASCAccessRowTableViewCell.swift */; };
@@ -788,6 +789,7 @@
 		1D8DF02E2639B6B10054B2F9 /* ASCOneDriveProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOneDriveProvider.swift; sourceTree = "<group>"; };
 		1D981FF22631A6AF00144B57 /* ASCOnlyofficeCategoriesProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeCategoriesProviderProtocol.swift; sourceTree = "<group>"; };
 		1D9820002631A8D900144B57 /* ASCOnlyofficeAppBasedCategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeAppBasedCategoriesProvider.swift; sourceTree = "<group>"; };
+		1D9B7FE926FA5A0000D06E9B /* ASCSharingOprionsInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCSharingOprionsInteractorTests.swift; sourceTree = "<group>"; };
 		1D9B807D2673EBEC0020B5ED /* ASCSwitchRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCSwitchRowViewModel.swift; sourceTree = "<group>"; };
 		1D9B80832673F5D70020B5ED /* ASCReusedIdentifierProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCReusedIdentifierProtocol.swift; sourceTree = "<group>"; };
 		1D9B808E2674001C0020B5ED /* ASCAccessRowTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCAccessRowTableViewCell.swift; sourceTree = "<group>"; };
@@ -1680,6 +1682,7 @@
 			children = (
 				1D14AAC52694F0AF009E48AD /* Workers */,
 				1DCCEC09268DBD9C00692167 /* ASCSharingOptionsViewControllerTest.swift */,
+				1D9B7FE926FA5A0000D06E9B /* ASCSharingOprionsInteractorTests.swift */,
 			);
 			path = SharingOptions;
 			sourceTree = "<group>";
@@ -2909,6 +2912,7 @@
 				"${BUILT_PRODUCTS_DIR}/FirebaseCoreDiagnostics/FirebaseCoreDiagnostics.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseCrashlytics/FirebaseCrashlytics.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseInstallations/FirebaseInstallations.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseInstanceID/FirebaseInstanceID.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseMessaging/FirebaseMessaging.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseRemoteConfig/FirebaseRemoteConfig.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
@@ -2970,6 +2974,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreDiagnostics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCrashlytics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstallations.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstanceID.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseMessaging.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseRemoteConfig.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
@@ -3201,6 +3206,7 @@
 				"${BUILT_PRODUCTS_DIR}/FirebaseCoreDiagnostics/FirebaseCoreDiagnostics.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseCrashlytics/FirebaseCrashlytics.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseInstallations/FirebaseInstallations.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseInstanceID/FirebaseInstanceID.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseMessaging/FirebaseMessaging.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseRemoteConfig/FirebaseRemoteConfig.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
@@ -3262,6 +3268,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreDiagnostics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCrashlytics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstallations.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstanceID.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseMessaging.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseRemoteConfig.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
@@ -3713,6 +3720,7 @@
 				FC4D864520C50AE00047B871 /* Date+Extension.swift in Sources */,
 				1D1A2E1F2660F93600D0335B /* ASCLoadedViewControllerByProviderAndFolderFinderTests.swift in Sources */,
 				FC77846C24756CC2005ED631 /* ASCFolderProviderType.swift in Sources */,
+				1D9B7FEA26FA5A0000D06E9B /* ASCSharingOprionsInteractorTests.swift in Sources */,
 				FCD31F4524BDF2E200774ACD /* ASCLogger.swift in Sources */,
 				1DCCEC0A268DBD9C00692167 /* ASCSharingOptionsViewControllerTest.swift in Sources */,
 				FC4D864920C50AE00047B871 /* Path+Extension.swift in Sources */,

--- a/Documents/Documents/Code/Business/Networking/NetworkingClient.swift
+++ b/Documents/Documents/Code/Business/Networking/NetworkingClient.swift
@@ -20,7 +20,20 @@ class ServerTrustPolicyManager: ServerTrustManager {
 
 }
 
-class NetworkingClient: NSObject {
+protocol NetworkingRequestingProtocol {
+    func request<Response> (
+        _ endpoint: Endpoint<Response>,
+        _ parameters: Parameters?,
+        _ completion: ((_ result: Response?, _ error: NetworkingError?) -> Void)?)
+    
+    func request<Response> (
+        _ endpoint: Endpoint<Response>,
+        _ parameters: Parameters?,
+        _ apply: ((_ data: MultipartFormData) -> Void)?,
+        _ completion: ((_ result: Response?, _ progress: Double, _ error: NetworkingError?) -> Void)?)
+}
+
+class NetworkingClient: NSObject, NetworkingRequestingProtocol {
     
     // MARK: - Properties
     

--- a/Documents/Documents/Code/Controllers/SharingSettings/SharingOprions/ASCSharingOptionsViewController.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/SharingOprions/ASCSharingOptionsViewController.swift
@@ -70,7 +70,7 @@ class ASCSharingOptionsViewController: ASCBaseTableViewController {
             let viewController        = self
             let interactor            = ASCSharingOptionsInteractor(entityLinkMaker: ASCOnlyofficeFileInternalLinkMaker(),
                                                                     entity: entity,
-                                                                    apiWorker: ASCShareSettingsAPIWorker())
+                                                                    apiWorker: ASCShareSettingsAPIWorker(), networkingRequestManager: OnlyofficeApiClient.shared)
             let presenter             = ASCSharingOptionsPresenter()
             let router                = ASCSharingOptionsRouter()
             viewController.interactor = interactor

--- a/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/ASCSharingOprionsInteractorTests.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/ASCSharingOprionsInteractorTests.swift
@@ -1,0 +1,98 @@
+//
+//  ASCASCSharingOprionsInteractorTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 21.09.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import XCTest
+import Alamofire
+import ObjectMapper
+@testable import Documents
+
+class ASCSharingOprionsInteractorTests: XCTestCase {
+    
+    var sut: ASCSharingOptionsInteractor!
+    var presenter: MockSharingOptionsPresentationLogic!
+    var apiWorker: MockShareSettingsAPIWorker!
+    var linkMaker: ASCEntityLinkMakerProtocol!
+    var networkingRequestManager: NetworkingRequestingProtocol!
+
+    override func setUpWithError() throws {
+        
+        presenter = MockSharingOptionsPresentationLogic()
+        apiWorker = MockShareSettingsAPIWorker()
+        linkMaker = MockLinkMaker()
+        networkingRequestManager = MockNetworkRequesting()
+        
+        sut = ASCSharingOptionsInteractor(entityLinkMaker: linkMaker, entity: ASCFile(), apiWorker: apiWorker, networkingRequestManager: networkingRequestManager)
+    }
+
+    override func tearDownWithError() throws {
+        presenter = nil
+        apiWorker = nil
+        linkMaker = nil
+        networkingRequestManager = nil
+    }
+    
+    func testChangingRightHolderAccessChengeDataStore() {
+        let rightHolder = ASCSharingRightHolder(id: "Foo", type: .user, access: .read, isOwner: false)
+        let user = ASCUser()
+        user.userId = "Foo"
+        
+        sut.sharedInfoItems.append(.init(access: rightHolder.access, user: user))
+        let expectation = expectation(description: "server expectation")
+        sut.makeRequest(request: .changeRightHolderAccess(.init(entity: ASCFile(), rightHolder: rightHolder, access: .comment)))
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            XCTAssertEqual(self.sut.sharedInfoItems[0].access, .comment)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+    }
+
+}
+
+extension ASCSharingOprionsInteractorTests {
+    
+    
+    class MockSharingOptionsPresentationLogic: ASCSharingOptionsPresentationLogic {
+        func presentData(response: ASCSharingOptions.Model.Response.ResponseType) { }
+    }
+    
+    class MockShareSettingsAPIWorker: ASCShareSettingsAPIWorkerProtocol {
+        func convertToParams(shareItems: [OnlyofficeShare]) -> [OnlyofficeShareItemRequestModel] {
+            []
+        }
+        
+        func convertToParams(items: [(rightHolderId: String, access: ASCShareAccess)]) -> [OnlyofficeShareItemRequestModel] {
+            []
+        }
+        func makeApiRequest(entity: ASCEntity) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>? {
+            let file = ASCFile()
+            file.id = "Foo"
+            return Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>(path: String(format: OnlyofficeAPI.Path.shareFile, file.id), decode: { _ in
+                OnlyofficeResponseArray<OnlyofficeShare>()
+            })
+        }
+    }
+    
+    class MockLinkMaker: ASCEntityLinkMakerProtocol {
+        func make(entity: ASCEntity) -> String? {
+            nil
+        }
+    }
+    
+    class MockNetworkRequesting: NetworkingRequestingProtocol {
+        func request<Response>(_ endpoint: Endpoint<Response>, _ parameters: Parameters?, _ completion: ((Response?, NetworkingError?) -> Void)?) {
+            completion?(nil, nil)
+        }
+        
+        func request<Response>(_ endpoint: Endpoint<Response>, _ parameters: Parameters?, _ apply: ((MultipartFormData) -> Void)?, _ completion: ((Response?, Double, NetworkingError?) -> Void)?) {
+            completion?(nil, 0, nil)
+        }
+        
+        
+    }
+    
+}


### PR DESCRIPTION
The local data repository was not updated when rights were changed, it was also sent to the Add Rights Holders screen. 
A unit test was added.
To be able to test the method of changing permissions, it was necessary to take the network singleton to a higher level and hide the queries behind the protocol.