### PR TITLE
Fixed bug #51251

### DIFF
--- a/Documents/Documents/Code/Controllers/Documents/ASCDocumentsViewController.swift
+++ b/Documents/Documents/Code/Controllers/Documents/ASCDocumentsViewController.swift
@@ -3075,16 +3075,12 @@ class ASCDocumentsViewController: ASCBaseTableViewController, UIGestureRecognize
                             completion?(nil)
                         } else {
                             strongSelf.insideTransfer(items: items, to: folder, move: move, overwride: overwride, completion: { entities in
-                                completion?(entities)
-                                guard let transfers = entities else {
-                                    completion?(nil)
+                                guard let _ = entities else {
+                                    completion?(items)
                                     return
                                 }
                                 
-                                if move {
-                                    transferNavigationVC.sourceProvider?.items.removeAll(transfers)
-                                    strongSelf.tableView.reloadData()
-                                }
+                                completion?(nil)
                                 
                                 if let destVC = getLoadedViewController(byFolderId: folder.id, andProviderId: provider.id) {
                                     destVC.loadFirstPage()


### PR DESCRIPTION
Inside transfer returns successfully transferred items, but the completion block expected incorrectly transferred items.
Fixed setting successfully transferred items to the completion block
Removed block of code with items removal, because it already exist in the completion block