### PR TITLE
Fixed bug #53677

### DIFF
--- a/Documents/Documents.xcodeproj/project.pbxproj
+++ b/Documents/Documents.xcodeproj/project.pbxproj
@@ -141,6 +141,13 @@
 		1DCCEC0A268DBD9C00692167 /* ASCSharingOptionsViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCCEC09268DBD9C00692167 /* ASCSharingOptionsViewControllerTest.swift */; };
 		1DE6D6BC2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE6D6BB2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift */; };
 		1DE6D6C42631BE03001B825B /* ASCOnlyofficeCategoriesProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE6D6C32631BE03001B825B /* ASCOnlyofficeCategoriesProviderFactory.swift */; };
+		1DEB996F274E2C7C0071C1DB /* ASCPersonalShareSettingsAPIWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB996E274E2C7C0071C1DB /* ASCPersonalShareSettingsAPIWorker.swift */; };
+		1DEB9971274E2EF90071C1DB /* ASCPersonalShareSettingsAPIWorkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB9970274E2EF90071C1DB /* ASCPersonalShareSettingsAPIWorkerTests.swift */; };
+		1DEB9973274E3ED10071C1DB /* ASCShareSettingsAPIWorkerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB9972274E3ED10071C1DB /* ASCShareSettingsAPIWorkerFactoryTests.swift */; };
+		1DEB9976274E46480071C1DB /* ASCShareSettingsAPIWorkerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB9975274E46480071C1DB /* ASCShareSettingsAPIWorkerFactory.swift */; };
+		1DEB9978274E4DC80071C1DB /* ASCAccessToAddRightHoldersCheckerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB9977274E4DC80071C1DB /* ASCAccessToAddRightHoldersCheckerProtocol.swift */; };
+		1DEB997A274E4E6A0071C1DB /* ASCAccessToAddRightHoldersCheckerByHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB9979274E4E6A0071C1DB /* ASCAccessToAddRightHoldersCheckerByHost.swift */; };
+		1DEB997C274E4F140071C1DB /* ASCAccessToAddRightHoldersCheckerByHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEB997B274E4F140071C1DB /* ASCAccessToAddRightHoldersCheckerByHostTests.swift */; };
 		1DF505242641867300B78496 /* ASCOneDriveFileProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF505232641867300B78496 /* ASCOneDriveFileProvider.swift */; };
 		1DF6E0A926D5323B00FB42CE /* ASCOneDriveProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF6E0A826D5323A00FB42CE /* ASCOneDriveProviderTests.swift */; };
 		667548327089FF37AB5BACBB /* Pods_Documents_Alpha.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92C4B2EE0CEF31DA5A45CD1A /* Pods_Documents_Alpha.framework */; };
@@ -835,6 +842,13 @@
 		1DCCEC09268DBD9C00692167 /* ASCSharingOptionsViewControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCSharingOptionsViewControllerTest.swift; sourceTree = "<group>"; };
 		1DE6D6BB2631AEE1001B825B /* ASCOnlyofficeAPICategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeAPICategoriesProvider.swift; sourceTree = "<group>"; };
 		1DE6D6C32631BE03001B825B /* ASCOnlyofficeCategoriesProviderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOnlyofficeCategoriesProviderFactory.swift; sourceTree = "<group>"; };
+		1DEB996E274E2C7C0071C1DB /* ASCPersonalShareSettingsAPIWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCPersonalShareSettingsAPIWorker.swift; sourceTree = "<group>"; };
+		1DEB9970274E2EF90071C1DB /* ASCPersonalShareSettingsAPIWorkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCPersonalShareSettingsAPIWorkerTests.swift; sourceTree = "<group>"; };
+		1DEB9972274E3ED10071C1DB /* ASCShareSettingsAPIWorkerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCShareSettingsAPIWorkerFactoryTests.swift; sourceTree = "<group>"; };
+		1DEB9975274E46480071C1DB /* ASCShareSettingsAPIWorkerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCShareSettingsAPIWorkerFactory.swift; sourceTree = "<group>"; };
+		1DEB9977274E4DC80071C1DB /* ASCAccessToAddRightHoldersCheckerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCAccessToAddRightHoldersCheckerProtocol.swift; sourceTree = "<group>"; };
+		1DEB9979274E4E6A0071C1DB /* ASCAccessToAddRightHoldersCheckerByHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCAccessToAddRightHoldersCheckerByHost.swift; sourceTree = "<group>"; };
+		1DEB997B274E4F140071C1DB /* ASCAccessToAddRightHoldersCheckerByHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCAccessToAddRightHoldersCheckerByHostTests.swift; sourceTree = "<group>"; };
 		1DF505232641867300B78496 /* ASCOneDriveFileProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOneDriveFileProvider.swift; sourceTree = "<group>"; };
 		1DF6E0A826D5323A00FB42CE /* ASCOneDriveProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASCOneDriveProviderTests.swift; sourceTree = "<group>"; };
 		223510FCC80632095899444E /* Pods_Documents_DocumentsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Documents_DocumentsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1329,6 +1343,7 @@
 			isa = PBXGroup;
 			children = (
 				1D14AAC32694F07C009E48AD /* ASCOnlyofficeFileInternalLinkMaker.swift */,
+				1DEB9979274E4E6A0071C1DB /* ASCAccessToAddRightHoldersCheckerByHost.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -1337,6 +1352,7 @@
 			isa = PBXGroup;
 			children = (
 				1D14AAC62694F0C4009E48AD /* ASCOnlyofficeFileInternalLinkMakerTests.swift */,
+				1DEB997B274E4F140071C1DB /* ASCAccessToAddRightHoldersCheckerByHostTests.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -1582,6 +1598,8 @@
 			isa = PBXGroup;
 			children = (
 				1D71107926A5A93000E00421 /* ASCShareSettingsAPIWorker.swift */,
+				1DEB996E274E2C7C0071C1DB /* ASCPersonalShareSettingsAPIWorker.swift */,
+				1DEB9975274E46480071C1DB /* ASCShareSettingsAPIWorkerFactory.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -1598,6 +1616,8 @@
 			isa = PBXGroup;
 			children = (
 				1D71107C26A5A9A000E00421 /* ASCShareSettingsAPIWorkerTests.swift */,
+				1DEB9970274E2EF90071C1DB /* ASCPersonalShareSettingsAPIWorkerTests.swift */,
+				1DEB9972274E3ED10071C1DB /* ASCShareSettingsAPIWorkerFactoryTests.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -1638,6 +1658,7 @@
 			children = (
 				1DCCEC04268CC6A600692167 /* ASCSharingOptionsSectionProtocol.swift */,
 				1D14AAC02694EFE4009E48AD /* ASCEntityLinkMakerProtocol.swift */,
+				1DEB9977274E4DC80071C1DB /* ASCAccessToAddRightHoldersCheckerProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -3772,17 +3793,20 @@
 			files = (
 				FCCDE680204973F500CFC653 /* ASCDocumentConverterTest.swift in Sources */,
 				FCD2DD6E2702F70400D31BD5 /* ManagedAppConfig.swift in Sources */,
+				1DEB997C274E4F140071C1DB /* ASCAccessToAddRightHoldersCheckerByHostTests.swift in Sources */,
 				FC56B5CB20C03F3400557C1F /* ASCSortViewCellTableViewCell.swift in Sources */,
 				FC4D864720C50AE00047B871 /* String+Extension.swift in Sources */,
 				1D14AAE226964AF2009E48AD /* ASCSharingSettingsAccessProviderFactoryTests.swift in Sources */,
 				FC4D864F20C50AE00047B871 /* UINavigationController+Extension.swift in Sources */,
 				FC4D864420C50AE00047B871 /* Data+Extension.swift in Sources */,
 				FC4D864320C50AE00047B871 /* Dictionary+Extension.swift in Sources */,
+				1DEB9973274E3ED10071C1DB /* ASCShareSettingsAPIWorkerFactoryTests.swift in Sources */,
 				1D14AAC72694F0C4009E48AD /* ASCOnlyofficeFileInternalLinkMakerTests.swift in Sources */,
 				FC4D864020C50A710047B871 /* UIDevice+Extension.swift in Sources */,
 				FC4D864820C50AE00047B871 /* MBProgressHUD+Extension.swift in Sources */,
 				1D1A2E412661018100D0335B /* Assets.swift in Sources */,
 				FC4D864220C50AE00047B871 /* Common+Extension.swift in Sources */,
+				1DEB9971274E2EF90071C1DB /* ASCPersonalShareSettingsAPIWorkerTests.swift in Sources */,
 				FC4D864C20C50AE00047B871 /* UIColor+Extension.swift in Sources */,
 				1D5DB04F265850B3006B4757 /* ASCOnlyofficeUserDefaultsCacheCategoriesProviderTests.swift in Sources */,
 				1D1A2E46266103AE00D0335B /* ASCLoadedViewControllerFinderProtocolTests.swift in Sources */,
@@ -3840,6 +3864,7 @@
 				FCD33B5B21C93C2B00D52DAF /* ASCCloudsEmptyViewController.swift in Sources */,
 				FC68528726837B7300D830EC /* OnlyofficeFileOperation.swift in Sources */,
 				FCB8A39221C27EE000CF74FA /* ASCDeviceCategoryViewController.swift in Sources */,
+				1DEB997A274E4E6A0071C1DB /* ASCAccessToAddRightHoldersCheckerByHost.swift in Sources */,
 				FC28F2C61E8D1BB200A8F985 /* ASCEntityManager.swift in Sources */,
 				FCC77C9E206D11B6001B7837 /* Path+Extension.swift in Sources */,
 				FCEF9D291ED2C94300627BA5 /* PasscodeSignButton.swift in Sources */,
@@ -4065,6 +4090,7 @@
 				FCEF9D351ED2D1D600627BA5 /* ASCUserDefaultsPasscodeRepository.swift in Sources */,
 				FC43E70F2195B5FC002AAA32 /* ASCYandexFileProvider.swift in Sources */,
 				E0609CA78B7ADE534424D45E /* ASCFolder.swift in Sources */,
+				1DEB996F274E2C7C0071C1DB /* ASCPersonalShareSettingsAPIWorker.swift in Sources */,
 				1DF505242641867300B78496 /* ASCOneDriveFileProvider.swift in Sources */,
 				FC708EE421B92E94001BBE5B /* UIBarButtonItem+Extensions.swift in Sources */,
 				FC059D9C1E82657F00BC2F5E /* ASCIndexTransform.swift in Sources */,
@@ -4087,6 +4113,7 @@
 				FC6839A221B81B1D00251CEA /* ASCOwnCloudProvider.swift in Sources */,
 				FC99FAF1226460F2000F1464 /* ASC2FAViewController.swift in Sources */,
 				FC41D80E2265DADC00A155C2 /* ASCFileProviderType.swift in Sources */,
+				1DEB9976274E46480071C1DB /* ASCShareSettingsAPIWorkerFactory.swift in Sources */,
 				FC4D0A242494F8B2001EF1B5 /* ASCLogIntercepter.swift in Sources */,
 				FC82827F21C3CC01005AF726 /* ASCDeviceSplitViewController.swift in Sources */,
 				FCA7501122BBD65A00991682 /* ASCCreateEntityView.swift in Sources */,
@@ -4098,6 +4125,7 @@
 				FC066AB4252DB7C5007357F7 /* ObservableProxy.swift in Sources */,
 				FC41D8022265D6EF00A155C2 /* ASCLoginType.swift in Sources */,
 				FCEF856C26C52E5F00173DDF /* UITextField+Style.swift in Sources */,
+				1DEB9978274E4DC80071C1DB /* ASCAccessToAddRightHoldersCheckerProtocol.swift in Sources */,
 				1D14AAF52698E85A009E48AD /* ASCSharingAddRightHoldersViewController.swift in Sources */,
 				FC68399621B7EF1000251CEA /* ASCOnlyofficeCategory.swift in Sources */,
 				FC9150F21EC35D850076A855 /* UIView+Extension.swift in Sources */,

--- a/Documents/Documents/Code/Business/Networking/Onlyoffice/OnlyofficeEndpoints.swift
+++ b/Documents/Documents/Code/Business/Networking/Onlyoffice/OnlyofficeEndpoints.swift
@@ -148,6 +148,9 @@ class OnlyofficeAPI {
         
         struct Sharing {
             static let removeSharingRights: Endpoint<OnlyofficeResponseType<Bool>> = Endpoint<OnlyofficeResponseType<Bool>>.make(Path.filesShare, .delete)
+            static func entitiesShare() -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>> {
+                Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>.make(Path.filesShare, .post)
+            }
             static func file(file: ASCFile) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>> {
                 return Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>.make(String(format: Path.shareFile, file.id), .put)
             }

--- a/Documents/Documents/Code/Controllers/Documents/ASCDocumentsViewController.swift
+++ b/Documents/Documents/Code/Controllers/Documents/ASCDocumentsViewController.swift
@@ -3316,8 +3316,6 @@ class ASCDocumentsViewController: ASCBaseTableViewController, UIGestureRecognize
                 // Remove data
                 for item in deteteItems {
                     if let indexPath = self.indexPath(by: item) {
-//                        self.tableData.remove(at: indexPath.row)
-//                        self.total -= 1
                         self.provider?.remove(at: indexPath.row)
                     }
                 }
@@ -3766,8 +3764,6 @@ extension ASCDocumentsViewController: ASCProviderDelegate {
     }
     
     func updateItems(provider: ASCFileProviderProtocol) {
-//        total = provider.total
-//        tableData = provider.items
         tableView.reloadData()
         
         // TODO: Or search diff and do it animated
@@ -3785,7 +3781,6 @@ extension ASCDocumentsViewController: ASCProviderDelegate {
             }
         }
     }
-    
     
     /// Helper function to present share screen from editors
     /// - Parameters:
@@ -4020,8 +4015,6 @@ extension ASCDocumentsViewController: UITableViewDropDelegate {
                                     for item in entities {
                                         if let indexPath = strongSelf.indexPath(by: item) {
                                             strongSelf.provider?.remove(at: indexPath.row)
-//                                            strongSelf.tableData.remove(at: indexPath.row)
-//                                            strongSelf.total -= 1
                                         }
                                     }
 

--- a/Documents/Documents/Code/Controllers/SharingSettings/Protocols/Workers/ASCShareSettingsAPIWorkerProtocol.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/Protocols/Workers/ASCShareSettingsAPIWorkerProtocol.swift
@@ -9,7 +9,32 @@
 import Foundation
 
 protocol ASCShareSettingsAPIWorkerProtocol {
+    typealias ASCEntityId = String
+    
     func convertToParams(shareItems: [OnlyofficeShare]) -> [OnlyofficeShareItemRequestModel]
     func convertToParams(items: [(rightHolderId: String, access: ASCShareAccess)]) -> [OnlyofficeShareItemRequestModel]
+    func convertToParams(entities: [ASCEntity]) -> [String: [ASCEntityId]]?
     func makeApiRequest(entity: ASCEntity) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>?
+}
+
+extension ASCShareSettingsAPIWorkerProtocol {
+    func convertToParams(shareItems: [OnlyofficeShare]) -> [OnlyofficeShareItemRequestModel] {
+        var shares: [OnlyofficeShareItemRequestModel] = []
+        
+        for share in shareItems {
+            if let itemId = share.user?.userId ?? share.group?.id {
+                shares.append(OnlyofficeShareItemRequestModel(shareTo: itemId, access: share.access))
+            }
+        }
+        
+        return shares
+    }
+    
+    func convertToParams(items: [(rightHolderId: String, access: ASCShareAccess)]) -> [OnlyofficeShareItemRequestModel] {
+        var shares: [OnlyofficeShareItemRequestModel] = []
+        for item in items {
+            shares.append(OnlyofficeShareItemRequestModel(shareTo: item.rightHolderId, access: item.access))
+        }
+        return shares
+    }
 }

--- a/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/ASCSharingOptionsModels.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/ASCSharingOptionsModels.swift
@@ -40,7 +40,7 @@ enum ASCSharingOptions {
         }
         struct Response {
             enum ResponseType {
-                case presentRightHolders(_ response: RightHoldersResponse)
+                case presentRightHolders(_ response: Result<RightHoldersResponse, Error>)
                 case presentChangeRightHolderAccess(_ response: ChangeRightHolderAccessResponse)
                 case presentRemoveRightHolderAccess(_ response: RemoveRightHolderAccessResponse)
             }
@@ -70,6 +70,7 @@ enum ASCSharingOptions {
                 case displayRightHolders(_ viewModel: RightHoldersViewModel)
                 case displayChangeRightHolderAccess(_ viewModel: ChangeRightHolderAccessViewModel)
                 case displayRemoveRightHolderAccess(_ viewModel: RemoveRightHolderAccessViewModel)
+                case displayError(_ message: String)
             }
             
             struct RightHoldersViewModel {

--- a/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/ASCSharingOptionsPresenter.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/ASCSharingOptionsPresenter.swift
@@ -18,35 +18,44 @@ class ASCSharingOptionsPresenter: ASCSharingOptionsPresentationLogic {
     func presentData(response: ASCSharingOptions.Model.Response.ResponseType) {
         switch response {
         
-        case .presentRightHolders(rightHoldersResponse: let rightHoldersResponse):
-            let sharedInfoItems = rightHoldersResponse.sharedInfoItems
-            let currentUser = rightHoldersResponse.currentUser
-            let isImportant: (OnlyofficeShare) -> Bool = { shareInfo in
-                var isShareInfoUserIsCurrenUser = false
-                if let shareInfoUserId = shareInfo.user?.userId,
-                   let currentUserId = currentUser?.userId
-                {
-                    isShareInfoUserIsCurrenUser = shareInfoUserId == currentUserId
-                }
-                return shareInfo.owner || isShareInfoUserIsCurrenUser
-            }
-            
-            var imprtantRightHolders: [ASCSharingRightHolderViewModel] = []
-            var otherRightHolders: [ASCSharingRightHolderViewModel] = []
-            
-            sharedInfoItems.forEach({ sharedInfo  in
-                if let viewModel = makeRightHolderViewModel(fromShareInfo: sharedInfo) {
-                    if isImportant(sharedInfo) {
-                        imprtantRightHolders.append(viewModel)
-                    } else {
-                        otherRightHolders.append(viewModel)
+        case .presentRightHolders(rightHoldersResponse: let rightHoldersResult):
+            switch rightHoldersResult {
+            case .success(let rightHoldersResponse):
+                let sharedInfoItems = rightHoldersResponse.sharedInfoItems
+                let currentUser = rightHoldersResponse.currentUser
+                let isImportant: (OnlyofficeShare) -> Bool = { shareInfo in
+                    var isShareInfoUserIsCurrenUser = false
+                    if let shareInfoUserId = shareInfo.user?.userId,
+                       let currentUserId = currentUser?.userId
+                    {
+                        isShareInfoUserIsCurrenUser = shareInfoUserId == currentUserId
                     }
+                    return shareInfo.owner || isShareInfoUserIsCurrenUser
                 }
-            })
-            viewController?.display(viewModel: .displayRightHolders(.init(internalLink: rightHoldersResponse.internalLink,
-                                                                          externalLink: rightHoldersResponse.externalLink,
-                                                                          importantRightHolders: imprtantRightHolders,
-                                                                          otherRightHolders: otherRightHolders)))
+                
+                var imprtantRightHolders: [ASCSharingRightHolderViewModel] = []
+                var otherRightHolders: [ASCSharingRightHolderViewModel] = []
+                
+                sharedInfoItems.forEach({ sharedInfo  in
+                    if let viewModel = makeRightHolderViewModel(fromShareInfo: sharedInfo) {
+                        if isImportant(sharedInfo) {
+                            imprtantRightHolders.append(viewModel)
+                        } else {
+                            otherRightHolders.append(viewModel)
+                        }
+                    }
+                })
+                viewController?.display(viewModel: .displayRightHolders(.init(internalLink: rightHoldersResponse.internalLink,
+                                                                              externalLink: rightHoldersResponse.externalLink,
+                                                                              importantRightHolders: imprtantRightHolders,
+                                                                              otherRightHolders: otherRightHolders)))
+            case .failure(let error):
+                viewController?.display(viewModel: .displayRightHolders(.init(internalLink: nil,
+                                                                              externalLink: nil,
+                                                                              importantRightHolders: [],
+                                                                              otherRightHolders: [])))
+                viewController?.display(viewModel: .displayError(error.localizedDescription))
+            }
         case .presentChangeRightHolderAccess(changeRightHolderResponse: let changeRightHolderResponse):
             viewController?.display(viewModel: .displayChangeRightHolderAccess(.init(rightHolder: changeRightHolderResponse.rightHolder,
                                                                                      error: changeRightHolderResponse.error)))

--- a/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/ASCSharingView.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/ASCSharingView.swift
@@ -38,7 +38,7 @@ class ASCSharingView {
         if #available(iOS 13.0, *) {
             icon = UIImage(systemName: "person.crop.circle.fill.badge.plus")
         } else {
-            icon = Asset.Images.navAdd.image // MARK: - todo replace the image
+            icon = Asset.Images.navAdd.image
         }
         return UIBarButtonItem(image: icon, style: .plain, target: self, action: #selector(onAddRightsBarButtonTap))
     }()
@@ -56,13 +56,17 @@ class ASCSharingView {
         navBarHeigh = navigationController?.navigationBar.height ?? 0
     }
     
-    public func configureNavigationItem(_ navigationItem: UINavigationItem) {
+    public func configureNavigationItem(_ navigationItem: UINavigationItem, allowAddRightHoders: Bool) {
         navigationItem.leftBarButtonItem = doneBarBtn
         navigationItem.title = NSLocalizedString("Sharing settings", comment: "")
-        navigationItem.rightBarButtonItems = [
-            addRightsBarButtonItem,
-            linkBarButtonItem
-        ]
+        
+        var items = [UIBarButtonItem]()
+        if allowAddRightHoders {
+            items.append(addRightsBarButtonItem)
+        }
+        items.append(linkBarButtonItem)
+        
+        navigationItem.rightBarButtonItems = items
     }
     
     public func configureTableView(_ tableView: UITableView) {

--- a/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/Protocols/ASCAccessToAddRightHoldersCheckerProtocol.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/Protocols/ASCAccessToAddRightHoldersCheckerProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ASCAccessToAddRightHoldersCheckerProtocol.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+protocol ASCAccessToAddRightHoldersCheckerProtocol {
+    func checkAccessToAddRightHolders() -> Bool
+}

--- a/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/Workers/ASCAccessToAddRightHoldersCheckerByHost.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/SharingOptions/Workers/ASCAccessToAddRightHoldersCheckerByHost.swift
@@ -1,0 +1,25 @@
+//
+//  ASCAccessToAddRightHoldersCheckerByHost.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+class ASCAccessToAddRightHoldersCheckerByHost: ASCAccessToAddRightHoldersCheckerProtocol {
+    let host: String?
+    
+    init(host: String?) {
+        self.host = host
+    }
+    
+    func checkAccessToAddRightHolders() -> Bool {
+        guard let host = host else {
+            return false
+        }
+        
+        return host != "personal.teamlab.info"
+    }
+}

--- a/Documents/Documents/Code/Controllers/SharingSettings/Workers/ASCPersonalShareSettingsAPIWorker.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/Workers/ASCPersonalShareSettingsAPIWorker.swift
@@ -1,0 +1,35 @@
+//
+//  ASCPersonalShareSettingsAPIWorker.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+class ASCPersonalShareSettingsAPIWorker: ASCShareSettingsAPIWorkerProtocol {
+
+    func makeApiRequest(entity: ASCEntity) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>? {
+        OnlyofficeAPI.Endpoints.Sharing.entitiesShare()
+    }
+    
+    func convertToParams(entities: [ASCEntity]) -> [String : [ASCEntityId]]? {
+        guard !entities.isEmpty else { return nil }
+        let filesIds: [String] = entities.compactMap({ ($0 as? ASCFile)?.id })
+        let foldersIds: [String] = entities.compactMap({ ($0 as? ASCFolder)?.id })
+        
+        guard !filesIds.isEmpty || !foldersIds.isEmpty else { return nil }
+        
+        var params: [String : [ASCEntityId]] = [:]
+        
+        if !filesIds.isEmpty {
+            params["fileIds"] = filesIds
+        }
+        if !foldersIds.isEmpty {
+            params["folderIds"] = foldersIds
+        }
+        
+        return params
+    }
+}

--- a/Documents/Documents/Code/Controllers/SharingSettings/Workers/ASCShareSettingsAPIWorker.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/Workers/ASCShareSettingsAPIWorker.swift
@@ -9,26 +9,7 @@
 import Foundation
 
 class ASCShareSettingsAPIWorker: ASCShareSettingsAPIWorkerProtocol {
-    func convertToParams(shareItems: [OnlyofficeShare]) -> [OnlyofficeShareItemRequestModel] {
-        var shares: [OnlyofficeShareItemRequestModel] = []
-        
-        for share in shareItems {
-            if let itemId = share.user?.userId ?? share.group?.id {
-                shares.append(OnlyofficeShareItemRequestModel(shareTo: itemId, access: share.access))
-            }
-        }
-        
-        return shares
-    }
-    
-    func convertToParams(items: [(rightHolderId: String, access: ASCShareAccess)]) -> [OnlyofficeShareItemRequestModel] {
-        var shares: [OnlyofficeShareItemRequestModel] = []
-        for item in items {
-            shares.append(OnlyofficeShareItemRequestModel(shareTo: item.rightHolderId, access: item.access))
-        }
-        return shares
-    }
-    
+
     func makeApiRequest(entity: ASCEntity) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>? {
         var request: Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>? = nil
         
@@ -37,7 +18,10 @@ class ASCShareSettingsAPIWorker: ASCShareSettingsAPIWorkerProtocol {
         } else if let folder = entity as? ASCFolder {
             request = OnlyofficeAPI.Endpoints.Sharing.folder(folder: folder)
         }
-        
         return request
+    }
+    
+    func convertToParams(entities: [ASCEntity]) -> [String : [ASCEntityId]]? {
+        nil
     }
 }

--- a/Documents/Documents/Code/Controllers/SharingSettings/Workers/ASCShareSettingsAPIWorkerFactory.swift
+++ b/Documents/Documents/Code/Controllers/SharingSettings/Workers/ASCShareSettingsAPIWorkerFactory.swift
@@ -1,0 +1,24 @@
+//
+//  ASCShareSettingsAPIWorkerFactory.swift
+//  Documents
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+class ASCShareSettingsAPIWorkerFactory {
+    func get(by portalHost: String?) -> ASCShareSettingsAPIWorkerProtocol {
+        let defaultAPIWorker = ASCShareSettingsAPIWorker()
+        guard let portalHost = portalHost else {
+            return defaultAPIWorker
+        }
+        
+        if portalHost == "personal.teamlab.info" {
+            return ASCPersonalShareSettingsAPIWorker()
+        }
+        
+        return defaultAPIWorker
+    }
+}

--- a/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/ASCSharingOprionsInteractorTests.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/ASCSharingOprionsInteractorTests.swift
@@ -68,6 +68,11 @@ extension ASCSharingOprionsInteractorTests {
         func convertToParams(items: [(rightHolderId: String, access: ASCShareAccess)]) -> [OnlyofficeShareItemRequestModel] {
             []
         }
+        
+        func convertToParams(entities: [ASCEntity]) -> [String: [String]]? {
+            nil
+        }
+        
         func makeApiRequest(entity: ASCEntity) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>? {
             let file = ASCFile()
             file.id = "Foo"

--- a/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/ASCSharingOptionsViewControllerTest.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/ASCSharingOptionsViewControllerTest.swift
@@ -100,10 +100,10 @@ extension ASCSharingOptionsViewControllerTest {
             switch request {
             case .loadRightHolders(_):
                 presenter?.presentData(
-                    response: .presentRightHolders(.init(sharedInfoItems: sharedInfoItems,
+                    response: .presentRightHolders(.success(.init(sharedInfoItems: sharedInfoItems,
                                                          currentUser: currentUser,
                                                          internalLink: internalLink,
-                                                         externalLink: externalLink)))
+                                                         externalLink: externalLink))))
             case .changeRightHolderAccess(_):
                 fatalError("doesn't implemented")
             case .removeRightHolderAccess(_):

--- a/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/Workers/ASCAccessToAddRightHoldersCheckerByHostTests.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/SharingOptions/Workers/ASCAccessToAddRightHoldersCheckerByHostTests.swift
@@ -1,0 +1,40 @@
+//
+//  ASCAccessToAddRightHoldersCheckerByHostTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import XCTest
+@testable import Documents
+
+class ASCAccessToAddRightHoldersCheckerByHostTests: XCTestCase {
+    
+    
+    var sut: ASCAccessToAddRightHoldersCheckerByHost!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testWhenNilHostThenReturnsFalse() {
+        sut = ASCAccessToAddRightHoldersCheckerByHost(host: nil)
+        XCTAssertFalse(sut.checkAccessToAddRightHolders())
+    }
+
+    func testWhenFooDotBarHostThenReturnsTrue() {
+        sut = ASCAccessToAddRightHoldersCheckerByHost(host: "foo.bar")
+        XCTAssertTrue(sut.checkAccessToAddRightHolders())
+    }
+    
+    func testWhenPersonalHoserThenReturnsFalse() {
+        sut = ASCAccessToAddRightHoldersCheckerByHost(host: "personal.teamlab.info")
+        XCTAssertFalse(sut.checkAccessToAddRightHolders())
+    }
+}

--- a/Documents/DocumentsTests/Controllers/SharingSettings/VerifyRightHolders/ASCSharingSettingsVerifyRightHoldersInteractorTests.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/VerifyRightHolders/ASCSharingSettingsVerifyRightHoldersInteractorTests.swift
@@ -11,7 +11,6 @@ import XCTest
 
 class ASCSharingSettingsVerifyRightHoldersInteractorTests: XCTestCase {
     
-    
     var sut: ASCSharingSettingsVerifyRightHoldersInteractor!
     var presenter: PresenterMock!
 
@@ -323,6 +322,12 @@ extension ASCSharingSettingsVerifyRightHoldersInteractorTests {
         
         func convertToParams(items: [(rightHolderId: String, access: ASCShareAccess)]) -> [OnlyofficeShareItemRequestModel] { [] }
         
+        func convertToParams(entities: [ASCEntity]) -> [String: [ASCEntityId]]? {
+            nil
+        }
+        
         func makeApiRequest(entity: ASCEntity) -> Endpoint<OnlyofficeResponseArray<OnlyofficeShare>>? { nil }
+        
+
     }
 }

--- a/Documents/DocumentsTests/Controllers/SharingSettings/Workers/ASCPersonalShareSettingsAPIWorkerTests.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/Workers/ASCPersonalShareSettingsAPIWorkerTests.swift
@@ -1,0 +1,125 @@
+//
+//  ASCPersonalShareSettingsAPIWorkerTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import Documents
+
+class ASCPersonalShareSettingsAPIWorkerTests: XCTestCase {
+    
+    var sut: ASCPersonalShareSettingsAPIWorker!
+
+    override func setUpWithError() throws {
+        sut = ASCPersonalShareSettingsAPIWorker()
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - makeApiRequest func tests
+    func testWhenMakeApiRequestOnFileGetsAString() {
+        let file = ASCFile()
+        file.id = "Foo"
+        
+        let request = sut.makeApiRequest(entity: file)
+        
+        XCTAssertNotNil(request)
+        XCTAssertFalse(request?.path.contains(file.id) ?? true)
+    }
+    
+    func testWhenMakeApiRequestOnFolderGetsAString() {
+        let folder = ASCFolder()
+        folder.id = "Foo"
+        
+        let request = sut.makeApiRequest(entity: folder)
+        
+        XCTAssertNotNil(request)
+        XCTAssertFalse(request?.path.contains(folder.id) ?? true)
+    }
+    
+    func testWhenMakeApiRequestOnEntityGetsAPIRequest() {
+        let entity = ASCEntity()
+        entity.id = "Foo"
+        
+        let request = sut.makeApiRequest(entity: entity)
+        
+        XCTAssertNotNil(request)
+    }
+
+    // MARK: - convertToParams func test
+    
+    func testWhenCallWithOneFileThenParamsHaveFileIdOnly() {
+        let file = getFileWithId(id: "Foo")
+        guard let params = sut.convertToParams(entities: [file]) else {
+            XCTFail("Couldn't get params from file")
+            return
+        }
+        
+        XCTAssertEqual(params.count, 1)
+        XCTAssertEqual(params["fileIds"], ["Foo"])
+    }
+    
+    func testWhenCallWithOneFolderThenParamsHaveFolderIdOnly() {
+        let folder = getFolderWithId(id: "Bar")
+        guard let params = sut.convertToParams(entities: [folder]) else {
+            XCTFail("Couldn't get params from file")
+            return
+        }
+        
+        XCTAssertEqual(params.count, 1)
+        XCTAssertEqual(params["folderIds"], ["Bar"])
+    }
+    
+    func testWhenCallWithTwoFilesAndThreeFoldersThenParamsHaveTwoFileIdsAndThreeFolderIds() {
+        let file1 = getFileWithId(id: "Foo1")
+        let file2 = getFileWithId(id: "Foo2")
+        let folder1 = getFolderWithId(id: "Bar1")
+        let folder2 = getFolderWithId(id: "Bar2")
+        let folder3 = getFolderWithId(id: "Bar3")
+        
+        guard let params = sut.convertToParams(entities: [file1, folder1, folder2, file2, folder3]) else {
+            XCTFail("Couldn't get params from file")
+            return
+        }
+        
+        XCTAssertEqual(params.count, 2)
+        
+        XCTAssertEqual(params["fileIds"], ["Foo1", "Foo2"])
+        XCTAssertEqual(params["folderIds"], ["Bar1", "Bar2", "Bar3"])
+    }
+    
+    func testWhenCallWithoutParamsConverterReturnsNil() {
+        let params = sut.convertToParams(entities: [])
+        XCTAssertNil(params)
+    }
+    
+    func testWhenCallWithASCEntitryConverterReturnsNil() {
+        let entity = ASCEntity()
+        entity.id = "Foo"
+        let params = sut.convertToParams(entities: [entity])
+        XCTAssertNil(params)
+    }
+    
+    // MARK: - help functions
+    
+    func getFileWithId(id: String) -> ASCFile {
+        let file = ASCFile()
+        file.id = id
+        return file
+    }
+    
+    func getFolderWithId(id: String) -> ASCFolder {
+        let folder = ASCFolder()
+        folder.id = id
+        return folder
+    }
+}

--- a/Documents/DocumentsTests/Controllers/SharingSettings/Workers/ASCShareSettingsAPIWorkerFactoryTests.swift
+++ b/Documents/DocumentsTests/Controllers/SharingSettings/Workers/ASCShareSettingsAPIWorkerFactoryTests.swift
@@ -1,0 +1,36 @@
+//
+//  ASCShareSettingsAPIWorkerFactoryTests.swift
+//  DocumentsTests
+//
+//  Created by Павел Чернышев on 24.11.2021.
+//  Copyright © 2021 Ascensio System SIA. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Documents
+
+class ASCShareSettingsAPIWorkerFactoryTests: XCTestCase {
+    
+    var sut: ASCShareSettingsAPIWorkerFactory!
+
+    override func setUpWithError() throws {
+        sut = ASCShareSettingsAPIWorkerFactory()
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testWhenPersonalHostReturnsPersonalWorker() {
+        let worker = sut.get(by: "personal.teamlab.info")
+        XCTAssertTrue(worker is ASCPersonalShareSettingsAPIWorker)
+    }
+    
+    func testWhenEmptyHostReturnsBaseShareSettingsWorker() {
+        let worker = sut.get(by: nil)
+        XCTAssertTrue(worker is ASCShareSettingsAPIWorker)
+    }
+}


### PR DESCRIPTION
The API method does not work for the personal portal. Now a different API method is used. Removed the ability to add rights holders for the personal portal, as on the site. Added error handling when loading rights holders. Added unit tests.